### PR TITLE
MAINT: tools/refguide_check.py: changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,25 +23,7 @@ matrix:
         - travis_retry pip install $NUMPYSPEC
         - travis_retry pip install nose argparse
         - travis_retry pip install matplotlib
-        - python runtests.py --doctests-only -s linalg
-        - python runtests.py --doctests-only -s cluster
-        - python runtests.py --doctests-only -s cluster.vq
-        - python runtests.py --doctests-only -s cluster.hierarchy
-        - python runtests.py --doctests-only -s fftpack
-        - python runtests.py --doctests-only -s interpolate
-        - python runtests.py --doctests-only -s integrate
-        - python runtests.py --doctests-only -s io
-        - python runtests.py --doctests-only -s misc
-        - python runtests.py --doctests-only -s ndimage
-        - python runtests.py --doctests-only -s odr
-        - python runtests.py --doctests-only -s optimize
-        - python runtests.py --doctests-only -s signal
-        - python runtests.py --doctests-only -s spatial
-        - python runtests.py --doctests-only -s sparse
-        - python runtests.py --doctests-only -s sparse.csgraph
-        - python runtests.py --doctests-only -s sparse.linalg
-        - python runtests.py --doctests-only -s stats
-        - python runtests.py --doctests-only -s stats.mstats
+        - python runtests.py --refguide-check
     - python: 3.4
       env:
         - TESTMODE=fast

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,16 +14,6 @@ matrix:
       script:
         - PYFLAKES_NODOCTEST=1 pyflakes scipy benchmarks/benchmarks | grep -E -v 'unable to detect undefined names|assigned to but never used|imported but unused|redefinition of unused' > test.out; cat test.out; test \! -s test.out
         - pep8 scipy benchmarks/benchmarks
-      after_success:
-        # run the doctests
-        - sudo apt-get update -qq
-        - sudo apt-get install -qq libatlas-dev libatlas-base-dev liblapack-dev gfortran
-        - sudo apt-get build-dep -qq python-matplotlib
-        - travis_retry pip install --install-option="--no-cython-compile" Cython==0.22
-        - travis_retry pip install $NUMPYSPEC
-        - travis_retry pip install nose argparse
-        - travis_retry pip install matplotlib
-        - python runtests.py --refguide-check
     - python: 3.4
       env:
         - TESTMODE=fast
@@ -52,6 +42,7 @@ matrix:
     - python: 2.7
       env:
         - TESTMODE=fast
+        - REFGUIDE_CHECK=1
         - COVERAGE=
         - NPY_RELAXED_STRIDES_CHECKING=1
         - NUMPYSPEC="--upgrade git+git://github.com/numpy/numpy.git@v1.9.1"
@@ -81,6 +72,11 @@ before_install:
   - travis_retry pip install nose mpmath argparse
   - travis_retry pip install gmpy2  # speeds up mpmath (scipy.special tests)
   - if [ "${TESTMODE}" == "full" ]; then pip install coverage coveralls; fi
+  - |
+    if [ "${REFGUIDE_CHECK}" == "1" ]; then
+        sudo apt-get build-dep -qq python-matplotlib
+        travis_retry pip install matplotlib
+    fi
   - python -V
   - popd
   - set -o pipefail
@@ -95,5 +91,5 @@ notifications:
   # let's wait to see what people think before turning that on.
   email: false
 after_success:
-    - if [ "${TESTMODE}" == "full" ]; then pushd build/testenv/lib/python*/site-packages/ && cp ../../../../test/.coverage . && coveralls && popd; fi
-
+  - if [ "${REFGUIDE_CHECK}" == "1" ]; then python runtests.py --refguide-check; fi
+  - if [ "${TESTMODE}" == "full" ]; then pushd build/testenv/lib/python*/site-packages/ && cp ../../../../test/.coverage . && coveralls && popd; fi

--- a/runtests.py
+++ b/runtests.py
@@ -72,8 +72,8 @@ def main(argv):
                         help="just build, do not run any tests")
     parser.add_argument("--doctests", action="store_true", default=False,
                         help="Run doctests in module")
-    parser.add_argument("--doctests-only", action="store_true", default=False,
-                        help="Only run doctests in submodule. (Do not run regular tests.)")
+    parser.add_argument("--refguide-check", action="store_true", default=False,
+                        help="Run refguide check (do not run regular tests.)")
     parser.add_argument("--coverage", action="store_true", default=False,
                         help=("report coverage of project code. HTML output goes "
                               "under build/coverage"))
@@ -176,13 +176,10 @@ def main(argv):
         extra_argv += ['--cover-html',
                        '--cover-html-dir='+dst_dir]
 
-    if args.doctests_only:
-        if not args.submodule:
-            print("*** No submodule specified: Use '-s optimize', '-s stats.mstats' etc.")
-            sys.exit(-1)
-        cmd = [os.path.join('tools', 'refguide_check.py'),
-               '--check_docs',
-               args.submodule,]
+    if args.refguide_check:
+        cmd = [os.path.join('tools', 'refguide_check.py'), '--doctests']
+        if args.submodule:
+            cmd += [args.submodule]
         os.execv(sys.executable, [sys.executable] + cmd)
         sys.exit(0)
 


### PR DESCRIPTION
Some updates:

- Easier to read output from tools/refguide_check.py
- Some cleanups
- Run refguide check in CI run that already builds scipy; running the doctests takes about 1 minute, building Scipy takes much longer. Probably useful to try to conserve CI resources.