### PR TITLE
interpolate.RGI: strengthen nan tests and fix PEP8

### DIFF
--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -2763,15 +2763,17 @@ class TestRegularGridInterpolator:
     @pytest.mark.parametrize("method", ['nearest', 'linear'])
     def test_nan_x_2d(self, method):
         x, y = np.array([0, 1, 2]), np.array([1, 3, 7])
+
         def f(x, y):
             return x**2 + y**2
+
         xg, yg = np.meshgrid(x, y, indexing='ij', sparse=True)
         data = f(xg, yg)
         interp = RegularGridInterpolator((x, y), data,
                                          method=method, bounds_error=False)
 
         res = interp([[1.5, np.nan], [1, 1]])
-        assert_allclose(res[1], 2, atol=1e-14 )
+        assert_allclose(res[1], 2, atol=1e-14)
         assert np.isnan(res[0])
 
         # test arbitrary nan pattern


### PR DESCRIPTION
Don't feel pressured to accept this if it's overkill for `interpolate`. I've just been conditioned by NaN bugs in `stats` to test these sorts of behaviors thoroughly.

```
__________________ TestRegularGridInterpolator.test_nan_x_2d ___________________
[gw1] linux -- Python 3.8.12 /opt/hostedtoolcache/Python/3.8.12/x64/bin/python
/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/scipy/interpolate/tests/test_interpolate.py:2762: in test_nan_x_2d
    res = interp([[1.5, np.nan], [1, 1]])
        data       = array([[ 1,  9, 49],
       [ 2, 10, 50],
       [ 5, 13, 53]])
        f          = <function TestRegularGridInterpolator.test_nan_x_2d.<locals>.f at 0x7f3b827d4ee0>
        interp     = <scipy.interpolate._interpolate.RegularGridInterpolator object at 0x7f3b82651100>
        self       = <scipy.interpolate.tests.test_interpolate.TestRegularGridInterpolator object at 0x7f3b958cef40>
        x          = array([0, 1, 2])
        xg         = array([[0],
       [1],
       [2]])
        y          = array([1, 3, 7])
        yg         = array([[1, 3, 7]])
/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/scipy/interpolate/_interpolate.py:2553: in __call__
    result = self._evaluate_nearest(indices,
        indices    = [array([1, 0]), array([1, 0])]
        is_method_changed = True
        method     = 'nearest'
        nans       = array([ True, False])
        ndim       = 2
        norm_distances = [array([0.5, 1. ]), array([nan,  0.])]
        out_of_bounds = array([False, False])
        self       = <scipy.interpolate._interpolate.RegularGridInterpolator object at 0x7f3b82651100>
```
