### PR TITLE
TST: interpolate: test batch behavior of BSplines

### DIFF
--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -3,6 +3,7 @@ import operator
 import itertools
 import math
 import threading
+import copy
 
 import numpy as np
 from numpy.testing import suppress_warnings
@@ -3720,3 +3721,69 @@ class TestMakeSplprep:
         assert spl(u).shape == (1, 8)
         xp_assert_close(spl(u), [x], atol=1e-15)
 
+
+class BatchSpline:
+    # BSpline-line class with reference batch behavior
+    def __init__(self, x, y, axis, *, spline, **kwargs):
+        y = np.moveaxis(y, axis, -1)
+        self._batch_shape = y.shape[:-1]
+        self._splines = [spline(x, yi, **kwargs) for yi in y.reshape(-1, y.shape[-1])]
+        self._axis = axis
+
+    def __call__(self, x):
+        y = [spline(x) for spline in self._splines]
+        y = np.reshape(y, self._batch_shape + x.shape)
+        return np.moveaxis(y, -1, self._axis) if x.shape else y
+
+    def integrate(self, a, b, extrapolate=None):
+        y = [spline.integrate(a, b, extrapolate) for spline in self._splines]
+        return np.reshape(y, self._batch_shape)
+
+    def derivative(self, nu):
+        res = copy.deepcopy(self)
+        res._splines = [spline.derivative(nu) for spline in res._splines]
+        return res
+
+    def antiderivative(self, nu):
+        res = copy.deepcopy(self)
+        res._splines = [spline.antiderivative(nu) for spline in res._splines]
+        return res
+
+
+class TestBatch:
+    @pytest.mark.parametrize('make_spline, kwargs',
+        [(make_interp_spline, {}),
+         (make_smoothing_spline, {}),
+         (make_smoothing_spline, {'lam': 1.0}),
+         (make_lsq_spline, {'method': "norm-eq"}),
+         (make_lsq_spline, {'method': "qr"}),
+         ])
+    @pytest.mark.parametrize('eval_shape', [(), (1,), (3,)])
+    @pytest.mark.parametrize('axis', [-1, 0, 1])
+    def test_batch(self, make_spline, kwargs, axis, eval_shape):
+        rng = np.random.default_rng(4329872134985134)
+        n = 10
+        shape = (2, 3, 4, n)
+        domain = (0, 10)
+
+        x = np.linspace(*domain, n)
+        y = np.moveaxis(rng.random(shape), -1, axis)
+
+        if make_spline == make_lsq_spline:
+            k = 3  # spline degree, if needed
+            t = (x[0],) * (k + 1) + (x[-1],) * (k + 1)  # valid knots, if needed
+            kwargs = kwargs | dict(t=t, k=k)
+
+        res = make_spline(x, y, axis=axis, **kwargs)
+        ref = BatchSpline(x, y, axis=axis, spline=make_spline, **kwargs)
+
+        x = rng.uniform(*domain, size=eval_shape)
+        np.testing.assert_allclose(res(x), ref(x))
+
+        res, ref = res.antiderivative(1), ref.antiderivative(1)
+        np.testing.assert_allclose(res(x), ref(x))
+
+        res, ref = res.derivative(2), ref.derivative(2)
+        np.testing.assert_allclose(res(x), ref(x))
+
+        np.testing.assert_allclose(res.integrate(*domain), ref.integrate(*domain))


### PR DESCRIPTION
#### Reference issue
scipy/scipy#22484

#### What does this implement/fix?
Common tests for BSpline batch behavior

#### Additional information
I was trying to be pretty comprehensive; I don't know enough about the implementations to decide whether this is overkill. 

Should `insert_knot` be added?

Were the classmethods supposed to be public? I noticed that [`construct_fast`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.BSpline.construct_fast.html#scipy.interpolate.BSpline.construct_fast) doesn't have documentation.